### PR TITLE
Fix/deploy ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,6 @@ jobs:
 
 workflows:
   version: 2
-  test:
-    jobs:
-      - test:
-        filters:
-          tags:
-            only: /.*/
   build_and_release:
     jobs:
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,6 @@ workflows:
           filters:
             branches:
               ignore: /.*/
-              only: master
             tags:
               only: /v[0-9]+(\.[0-9]+(dev|)([0-9]+|))*/
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,12 @@ jobs:
 
 workflows:
   version: 2
+  test:
+    jobs:
+      - test:
+        filters:
+          tags:
+            only: /.*/
   build_and_release:
     jobs:
       - test:


### PR DESCRIPTION
Only try to deploy if a tag of the form `v0.6.1` is specified.