### PR TITLE
Feature/ens

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,9 @@ legions
 |                 | accounts          | Investigate accounts (e.g. check if accounts are unlocked, etc)                |
 |                 | admin             | Investigate accounts (e.g. functionalities under the admin_ namespace)         |
 |                 | sign              | Investigate signature functionalities                                          |
+|     **ens**     |                   | **Do Ethereum Name Service queries (supported on the mainnet only)**           |
+|                 | toName            | Transform an address to the ENS name                                           |
+|                 | toAddress         | Transform an ENS name to the Ethereum public address                           |
 |   **version**   |                   | **Print Versions** (If connected to a node it will print the host version too) |
 
 

--- a/legions/commands/more/ens.py
+++ b/legions/commands/more/ens.py
@@ -6,6 +6,7 @@ from nubia import command, argument
 
 w3 = Web3()
 
+
 @command
 class ens:
     "Ethereum name system"

--- a/legions/commands/more/ens.py
+++ b/legions/commands/more/ens.py
@@ -29,10 +29,31 @@ class ens:
     @argument("value", description="name to be converted to an address")
     def toAddress(self, value: str) -> str:
         """
-        Converts a ens name to an address
+        Converts a ENS name to an address
         """
 
         try:
             cprint("Address of {}: {}".format(value, self.ns.address(value)))
         except Exception as e:
             cprint("Failed to convert {}: {}".format(value, e), "yellow")
+
+    @command("info")
+    @argument("name", description="name to get information about")
+    def info(self, name: str) -> str:
+        """
+        Get info about an ENS name
+        """
+
+        cprint("Information about '{}'".format(name))
+        cprint("Valid name: {}".format(self.ns.is_valid_name(name)))
+
+        if self.ns.is_valid_name(name):
+            cprint("Namehash: {}".format(self.ns.namehash(name).hex()))
+
+            resolver = self.ns.resolver(name)
+            if resolver is not None:
+                cprint("Resolver: {}".format(resolver.address))
+                cprint("Owner: {}".format(self.ns.owner(name)))
+            else:
+                cprint("Is not registered")
+

--- a/legions/commands/more/ens.py
+++ b/legions/commands/more/ens.py
@@ -2,9 +2,7 @@ from ens import ENS as _ens
 from web3 import Web3
 from termcolor import cprint
 from nubia import command, argument
-
-
-w3 = Web3()
+from legions.commands.commands import w3
 
 
 @command

--- a/legions/commands/more/ens.py
+++ b/legions/commands/more/ens.py
@@ -56,4 +56,3 @@ class ens:
                 cprint("Owner: {}".format(self.ns.owner(name)))
             else:
                 cprint("Is not registered")
-

--- a/legions/commands/more/ens.py
+++ b/legions/commands/more/ens.py
@@ -1,0 +1,39 @@
+from ens import ENS as _ens
+from web3 import Web3
+from termcolor import cprint
+from nubia import command, argument
+
+
+w3 = Web3()
+
+@command
+class ens:
+    "Ethereum name system"
+
+    def __init__(self) -> None:
+        self.ns = _ens.fromWeb3(w3)
+        pass
+
+    @command("toName")
+    @argument("value", description="address to be converted to a name")
+    def toName(self, value: str) -> str:
+        """
+        Converts an address to a ens name
+        """
+
+        try:
+            cprint("Name of {}: {}".format(value, self.ns.name(value)))
+        except Exception as e:
+            cprint("Failed to convert {}: {}".format(value, e), "yellow")
+
+    @command("toAddress")
+    @argument("value", description="name to be converted to an address")
+    def toAddress(self, value: str) -> str:
+        """
+        Converts a ens name to an address
+        """
+
+        try:
+            cprint("Address of {}: {}".format(value, self.ns.address(value)))
+        except Exception as e:
+            cprint("Failed to convert {}: {}".format(value, e), "yellow")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 dataclasses;python_version>='3.6'
-web3==5.4.0
+web3==5.7.0
 python-nubia==0.2b2


### PR DESCRIPTION
Add ENS queries

### `toName`

```console
daniel> ens toName value="0xC73Add416E2119d20cE80E0904FC1877e33EF246"                                                                                                                     
Name of 0xC73Add416E2119d20cE80E0904FC1877e33EF246: cleanunicorn.eth
```

### `toAddress`

```console
daniel> ens toAddress value="cleanunicorn.eth"                                                                                                                                            
Address of cleanunicorn.eth: 0xC73Add416E2119d20cE80E0904FC1877e33EF246
```

## `info`

```console
daniel> ens info name="cleanunicorn.eth"                                                                                                                                              
Information about 'cleanunicorn.eth'
Valid name: True
Namehash: 0xb2c893571f9e3c572e8e7198ca686cca2c73c953c2b671b977e42aee9aef0a16
Resolver: 0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41
Owner: 0xC73Add416E2119d20cE80E0904FC1877e33EF246
```

Todo
Show Information:
  - [x] (Public / private) resolver address
  - [x] Namehash
  - [ ] Registration & Expiration Date
  - [ ] Show records
      - [x] Address
      - [ ] Content (IPFS, onion, etc)
      - [ ] Text
   - [ ] Subdomains
- [ ] handle old and new ENS registray ( a lot of domains have not migrated to new resolvers)
- [x] Reverse name lookup
 - [ ] Handle multiple address <> names

Most of these functionality (if not all) are implemented in [ens.domains](https://github.com/ensdomains/ens.domains), but in web3.js, however it should be trivial to port them to web3.py

